### PR TITLE
Fix subtle blue outline

### DIFF
--- a/static/src/investment-report.css
+++ b/static/src/investment-report.css
@@ -301,7 +301,7 @@ ul li:before {
 }
 
 .singlepage-withfooter__footer {
-  background: blue;
+  background: white;
   flex-grow: 1;
   background-size: cover;
   background-position: center;


### PR DESCRIPTION
Fixes subtle blue outline that shows when image is all white.
<img width="897" alt="screen shot 2018-06-29 at 11 03 09" src="https://user-images.githubusercontent.com/8541009/42086784-1606667c-7b8c-11e8-84f3-d6e2092e8601.png">
