### PR TITLE
Bump cryptography to 41.0.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -41,7 +41,7 @@ requests[security]==2.31.0
 pyyaml==6.0.0
 django-environ==0.4.5
 oauthlib==3.2.2
-cryptography==41.0.4
+cryptography==41.0.7
 urllib3>=1.26.18
 # Latest django-moderation release(0.0.7) package has restriction for django upto 2.2 and we wanted to install
 # django 2.2.24 for critical vulnerabilities - hence installing from master

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,9 +40,7 @@ cairocffi==1.6.1
 cairosvg==2.7.1
     # via weasyprint
 celery[redis]==5.3.5
-    # via
-    #   -r requirements.in
-    #   celery
+    # via -r requirements.in
 certifi==2023.7.22
     # via
     #   -r requirements.in
@@ -66,7 +64,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-cryptography==41.0.4
+cryptography==41.0.7
     # via -r requirements.in
 cssselect2==0.7.0
     # via
@@ -225,7 +223,6 @@ requests[security]==2.31.0
     #   -r requirements.in
     #   django-countries-plus
     #   notifications-python-client
-    #   requests
     #   requests-oauthlib
     #   zenpy
 requests-oauthlib==1.3.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -42,9 +42,7 @@ cairocffi==1.6.1
 cairosvg==2.7.1
     # via weasyprint
 celery[redis]==5.2.3
-    # via
-    #   -r requirements.in
-    #   celery
+    # via -r requirements.in
 certifi==2023.7.22
     # via
     #   -r requirements.in
@@ -70,10 +68,9 @@ click-repl==0.2.0
     # via celery
 coverage[toml]==7.2.5
     # via
-    #   coverage
     #   pytest-codecov
     #   pytest-cov
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements.in
     #   moto
@@ -283,7 +280,6 @@ requests[security]==2.31.0
     #   moto
     #   notifications-python-client
     #   pytest-codecov
-    #   requests
     #   requests-oauthlib
     #   responses
     #   zenpy


### PR DESCRIPTION
Bump cryptography to 41.0.7

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1688
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Upgraded any vulnerable dependencies.
- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
